### PR TITLE
Fix compile errors preventing package from being usable in 2019.4

### DIFF
--- a/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.cs
+++ b/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.cs
@@ -142,9 +142,8 @@ namespace MissingReferencesHunter
                     (float) count / assetPaths.Count);
                 count++;
 
-                var guid = AssetDatabase.GUIDFromAssetPath(assetPath);
+                var guidStr = AssetDatabase.AssetPathToGUID(assetPath);
 
-                var guidStr = guid.ToString();
                 _result.Guids.Add(guidStr);
 
                 if (filesToAnalyze.Count > 0 && !filesToAnalyze.Contains(assetPath))
@@ -281,7 +280,7 @@ namespace MissingReferencesHunter
                     }
                 }
                 
-                _result.Assets.Add(new AssetData(assetPath, type, typeName, guid, refsData));
+                _result.Assets.Add(new AssetData(assetPath, type, typeName, guidStr, refsData));
             }
             
             foreach (var asset in _result.Assets)
@@ -624,7 +623,7 @@ namespace MissingReferencesHunter
                 
                 prevColor = GUI.color;
                 GUI.color = Color.gray;
-                EditorGUILayout.LabelField(asset.GuidContents, GUILayout.Width(250f));
+                EditorGUILayout.LabelField(asset.Guid, GUILayout.Width(250f));
                 GUI.color = prevColor;
                 
                 EditorGUILayout.LabelField(asset.Path);
@@ -702,21 +701,19 @@ namespace MissingReferencesHunter
     
     public class AssetData
     {
-        public AssetData(string path, Type type, string typeName, GUID guid, AssetReferencesData refsData)
+        public AssetData(string path, Type type, string typeName, string guid, AssetReferencesData refsData)
         {
             Path = path;
             Type = type;
             TypeName = typeName;
             Guid = guid;
-            GuidContents = guid.Empty() ? string.Empty : guid.ToString();
             RefsData = refsData;
         }
 
         public string Path { get; }
         public Type Type { get; }
         public string TypeName { get; }
-        public GUID Guid { get; }
-        public string GuidContents { get; }
+        public string Guid { get; }
         public AssetReferencesData RefsData { get; }
         public bool ValidType => Type != null;
     }

--- a/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.cs
+++ b/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.cs
@@ -376,7 +376,7 @@ namespace MissingReferencesHunter
                                                   || DerivesFromOrEqual(type, typeof(ScriptableObject));
             }
             
-            static bool DerivesFromOrEqual(Type a, Type b)
+            bool DerivesFromOrEqual(Type a, Type b)
             {
 #if UNITY_WSA && ENABLE_DOTNET && !UNITY_EDITOR
                 return b == a || b.GetTypeInfo().IsAssignableFrom(a.GetTypeInfo());


### PR DESCRIPTION
There were 2 things that caused compile errors when importing the package in 2019.4, explained in commit messages (note the caveat regarding how deleted assets are treated due to [this](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/AssetDatabase.AssetPathToGUID.html#:~:text=However%2C%20recently%20deleted%20assets%20return%20a%20GUID%20until%20the%20Unity%20Editor%20is%20restarted.)).

After fixing them I ran the analysis on a pretty large project, and it finished successfully, albeit taking more than 2 hours to finish (project's Assets dir is 18GB + there are many packages in use).

I also fixed up the sample project in this repo to be able to run the analysis on it from 2019.4 (changes are 8606089d60 on [this branch](https://github.com/bgr/Unity-MissingReferences-Hunter/tree/fix/manifest-adapted-for-2019.4) I didn't make a PR for that), and running the analysis gave 4 results, I don't know if that's the expected result.