### PR TITLE
Fix clashes with DependenciesHunter

### DIFF
--- a/Packages/MissingRefsHunter/Editor.meta
+++ b/Packages/MissingRefsHunter/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 427bed4cee004e54fbd9dac8db64ae36
+guid: 148b1f434bab04b47bcdcf3c31b8d859
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.Editor.asmdef
+++ b/Packages/MissingRefsHunter/Editor/MissingReferencesHunter.Editor.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "DependenciesHunter.Editor",
+    "name": "MissingReferencesHunter.Editor",
     "references": [],
     "includePlatforms": [
         "Editor"

--- a/Packages/MissingRefsHunter/LICENSE.meta
+++ b/Packages/MissingRefsHunter/LICENSE.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3cddc2982489c034787517f8be606b57
+guid: 957c5c1d3a1b1924394462d0a24fc880
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Packages/MissingRefsHunter/README.md.meta
+++ b/Packages/MissingRefsHunter/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: df50c01820a0fb54592a8f18870429d0
+guid: 53a511fe4e317c84f9ef983ad2220304
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Packages/MissingRefsHunter/package.json.meta
+++ b/Packages/MissingRefsHunter/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9f4595f99d95359468bf8d3fbaf7f71e
+guid: 492df23f237984a4cb090fec798c4634
 PackageManifestImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
Several files used the same GUIDs as in [DependenciesHunter ](https://github.com/AlexeyPerov/Unity-Dependencies-Hunter), and the .asmdef file used its name.

This was preventing both packages from being imported into same project simultaneously.

Note that this happened when importing via Package Manager in which case the imported packages' files are considered read-only by Unity, which causes the error spam. This might get unnoticed when importing differently where Unity is known to auto-fix GUID clashes by assigning new ones, although I'm not sure it'd auto-fix the .asmdef name clash.